### PR TITLE
Add Windows launchers, policy safeguards, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip install black ruff pytest
+      - run: ruff .
+      - run: black --check .
+      - run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+
+# Virtualenv
+.venv/
+
+# Logs and runtime files
+var/*.log*
+var/memory.*
+
+# Others
+*.egg-info/
+.dist/
+.build/
+pytest_cache/
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
+    hooks:
+      - id: ruff

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 HelmOS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@ cd HelmOS
 ./scripts/install.sh
 ./scripts/run_dev.sh
 ```
+
+Windows quick start:
+```powershell
+cd HelmOS
+./scripts/install.ps1
+./scripts/run_dev.ps1
+```
+
+Uninstall:
+```
+Delete the HelmOS/ folder.
+```
+
+Troubleshooting:
+
+- Set PowerShell execution policy if scripts won't run: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`
+- Activate the virtual environment manually: `source .venv/bin/activate` (bash) or `. .venv\Scripts\Activate.ps1` (PowerShell)
+- Ensure Python 3.11+ is installed and on PATH.
+
+Privacy: HelmOS runs entirely locally; no data leaves your machine. Memory keys live under `var/memory.key`.

--- a/ai/cortex/main.py
+++ b/ai/cortex/main.py
@@ -1,8 +1,13 @@
-import re, shlex, json
+import json
+import re
+import shlex
 from pathlib import Path
+
 import yaml
-from core.skill_api import autoload_skills, registry
+
 from core.audit_log import log
+from core.skill_api import autoload_skills, registry
+
 ROOT = Path(__file__).resolve().parents[2]
 autoload_skills(ROOT)
 HELP = (
@@ -11,58 +16,68 @@ HELP = (
     "  run <cmd>\n"
     "  note add <t>\n"
     "  note list\n"
-    "  git clone <url> <path>\n"
-    "  git status <path>\n"
-    "  git commit <path> <msg>\n"
+    "  git status|diff|branch|switch <name>\n"
     "  sysinfo\n"
     "  policy show\n"
     "  policy set <key> <value>\n"
+    "  policy edit\n"
+    "  skill list\n"
     "  help\n"
     "  exit\n"
 )
+
+
 def handle(text: str) -> str:
     t = text.strip()
-    if not t: return ""
-    if t in ("help","?"): return HELP
-    if t == "exit": return "__EXIT__"
+    if not t:
+        return ""
+    if t in ("help", "?"):
+        return HELP
+    if t == "exit":
+        return "__EXIT__"
     m = re.match(r"^search\s+(.+)$", t, re.I)
     if m:
-        q = m.group(1); log("cortex", f"file.search '{q}'", reason="user")
+        q = m.group(1)
+        log("cortex", f"file.search '{q}'", reason="user")
         res = registry.call("file.search.search", query=q)
-        if not res.ok: return f"Error: {res.error}"
+        if not res.ok:
+            return f"Error: {res.error}"
         items = res.data[:10]
-        return "\n".join([f"- {i['path']}: {i['snippet']}" for i in items]) if items else "No results."
+        if not items:
+            return "No results."
+        return "\n".join([f"- {i['path']}: {i['snippet']}" for i in items])
     m = re.match(r"^run\s+(.+)$", t, re.I)
     if m:
-        cmd = m.group(1); log("cortex", f"system.run '{cmd}'", reason="user")
+        cmd = m.group(1)
+        log("cortex", f"system.run '{cmd}'", reason="user")
         res = registry.call("system.run.exec", cmdline=cmd)
         return res.data if res.ok else f"Error: {res.error}"
     if t.startswith("note "):
         args = t.split(" ", 2)
-        if len(args)==2 and args[1]=="list":
-            res = registry.call("notes.list"); return res.data if res.ok else f"Error: {res.error}"
-        if len(args)>=3 and args[1]=="add":
-            res = registry.call("notes.add", text=args[2]); return res.data if res.ok else f"Error: {res.error}"
+        if len(args) == 2 and args[1] == "list":
+            res = registry.call("notes.list")
+            return res.data if res.ok else f"Error: {res.error}"
+        if len(args) >= 3 and args[1] == "add":
+            res = registry.call("notes.add", text=args[2])
+            return res.data if res.ok else f"Error: {res.error}"
         return "Usage: note add <text> | note list"
     if t == "sysinfo":
         res = registry.call("system.info.get")
         return json.dumps(res.data, indent=2) if res.ok else f"Error: {res.error}"
-    m = re.match(r"^git\s+(clone|status|commit)\s+(.+)$", t, re.I)
+    m = re.match(r"^git\s+(status|diff|branch|switch)(.*)$", t, re.I)
     if m:
         cmd = m.group(1).lower()
         rest = shlex.split(m.group(2))
-        try:
-            if cmd == "clone" and len(rest) == 2:
-                res = registry.call("git.clone", url=rest[0], path=rest[1])
-            elif cmd == "status" and len(rest) == 1:
-                res = registry.call("git.status", path=rest[0])
-            elif cmd == "commit" and len(rest) >= 2:
-                repo = rest[0]; message = " ".join(rest[1:])
-                res = registry.call("git.commit", path=repo, message=message)
-            else:
-                return "Usage: git clone <url> <path> | git status <path> | git commit <path> <msg>"
-        except Exception as e:
-            return f"Error: {e}"
+        if cmd == "status":
+            res = registry.call("git.status")
+        elif cmd == "diff":
+            res = registry.call("git.diff_stat")
+        elif cmd == "branch":
+            res = registry.call("git.branch")
+        elif cmd == "switch" and rest:
+            res = registry.call("git.switch", name=rest[0])
+        else:
+            return "Usage: git status | git diff | git branch | git switch <name>"
         return res.data if res.ok else f"Error: {res.error}"
     if t == "policy show":
         res = registry.call("config.policy.get")
@@ -72,4 +87,9 @@ def handle(text: str) -> str:
         key, val = m.group(1), m.group(2)
         res = registry.call("config.policy.set", key=key, value=val)
         return res.data if res.ok else f"Error: {res.error}"
+    if t == "policy edit":
+        res = registry.call("config.policy.edit")
+        return res.data if res.ok else f"Error: {res.error}"
+    if t == "skill list":
+        return "\n".join(registry.list_endpoints())
     return "Unknown command. Type 'help'."

--- a/ai/hippocampus/memory.py
+++ b/ai/hippocampus/memory.py
@@ -1,20 +1,31 @@
 from pathlib import Path
+
 from cryptography.fernet import Fernet
+
 KEY_PATH = Path("var/memory.key")
 MEMO_PATH = Path("var/memory.txt.enc")
+
+
 def ensure_key():
     KEY_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not KEY_PATH.exists():
         KEY_PATH.write_bytes(Fernet.generate_key())
+
+
 def append_memory(text: str):
     ensure_key()
-    key = KEY_PATH.read_bytes(); f = Fernet(key)
+    key = KEY_PATH.read_bytes()
+    f = Fernet(key)
     current = MEMO_PATH.read_bytes() if MEMO_PATH.exists() else b""
     data = f.decrypt(current) if current else b""
     data += (text + "\n").encode()
     MEMO_PATH.write_bytes(f.encrypt(data))
+
+
 def read_memory() -> str:
     ensure_key()
-    key = KEY_PATH.read_bytes(); f = Fernet(key)
-    if not MEMO_PATH.exists(): return ""
+    key = KEY_PATH.read_bytes()
+    f = Fernet(key)
+    if not MEMO_PATH.exists():
+        return ""
     return f.decrypt(MEMO_PATH.read_bytes()).decode()

--- a/cli/palette.py
+++ b/cli/palette.py
@@ -1,8 +1,16 @@
+import traceback
+from pathlib import Path
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import FileHistory
-from pathlib import Path
+
 from ai.cortex.main import handle
-HIST = Path("var/history.txt"); HIST.parent.mkdir(parents=True, exist_ok=True)
+
+HIST = Path("var/history.txt")
+HIST.parent.mkdir(parents=True, exist_ok=True)
+ERR = Path("var/error.log")
+
+
 def main():
     session = PromptSession(message=lambda: "HelmOS> ", history=FileHistory(str(HIST)))
     print("HelmOS — Keyboard Palette (type 'help' or 'exit')")
@@ -10,9 +18,22 @@ def main():
         try:
             text = session.prompt()
         except KeyboardInterrupt:
-            print("^C"); continue
-        out = handle(text)
-        if out == "__EXIT__": print("Bye."); break
-        if out: print(out)
+            print("^C")
+            continue
+        try:
+            out = handle(text)
+        except Exception:
+            ERR.parent.mkdir(parents=True, exist_ok=True)
+            with ERR.open("a") as fh:
+                fh.write(traceback.format_exc())
+            print("Error: see var/error.log")
+            continue
+        if out == "__EXIT__":
+            print("Bye.")
+            break
+        if out:
+            print(out)
+
+
 if __name__ == "__main__":
     main()

--- a/configs/policies/default.yaml
+++ b/configs/policies/default.yaml
@@ -9,4 +9,9 @@ allowed_commands:
   - cat
   - uname
   - date
+denied_commands:
+  - rm
+  - sudo
+  - powershell
 require_approval: false
+prompt_on_write: false

--- a/core/audit_log.py
+++ b/core/audit_log.py
@@ -1,10 +1,30 @@
 from datetime import datetime
 from pathlib import Path
+
 LOG_PATH = Path("var/audit.log")
+MAX_BYTES = 5 * 1024 * 1024
+BACKUPS = 2
+
+
+def _rotate():
+    if LOG_PATH.exists() and LOG_PATH.stat().st_size > MAX_BYTES:
+        for i in range(BACKUPS, 0, -1):
+            src = LOG_PATH.with_suffix(f".log.{i}")
+            dst = LOG_PATH.with_suffix(f".log.{i + 1}")
+            if src.exists():
+                if i == BACKUPS and dst.exists():
+                    dst.unlink()
+                src.rename(dst)
+        LOG_PATH.rename(LOG_PATH.with_suffix(".log.1"))
+
+
 def log(actor: str, action: str, reason: str = ""):
     LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _rotate()
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     line = f"[{now}] {actor}: {action}"
-    if reason: line += f" | reason: {reason}"
+    if reason:
+        line += f" | reason: {reason}"
     line += "\n"
-    LOG_PATH.write_text(LOG_PATH.read_text() + line if LOG_PATH.exists() else line)
+    with LOG_PATH.open("a") as fh:
+        fh.write(line)

--- a/core/policy_engine.py
+++ b/core/policy_engine.py
@@ -1,13 +1,21 @@
 from pathlib import Path
-import yaml
 from typing import List
+
+import yaml
+
 POLICY_PATH = Path("configs/policies/default.yaml")
+
+
 class Policy:
     def __init__(self, data: dict):
         self.allowed_paths: List[str] = data.get("allowed_paths", [])
         self.denied_paths: List[str] = data.get("denied_paths", [])
         self.allowed_commands: List[str] = data.get("allowed_commands", [])
+        self.denied_commands: List[str] = data.get("denied_commands", [])
         self.require_approval: bool = data.get("require_approval", False)
+        self.prompt_on_write: bool = data.get("prompt_on_write", False)
+
+
 def load_policy() -> Policy:
     data = yaml.safe_load(POLICY_PATH.read_text())
     return Policy(data)

--- a/core/skill_api.py
+++ b/core/skill_api.py
@@ -1,24 +1,47 @@
-import importlib, pkgutil
-from typing import Callable, Dict, Any, Optional
+import importlib
+import pkgutil
+from typing import Any, Callable, Dict, Optional
+
 from pydantic import BaseModel
+
+
 class Result(BaseModel):
     ok: bool = True
     data: Any = None
     error: Optional[str] = None
+
+
 class SkillRegistry:
-    def __init__(self):
+    def __init__(self) -> None:
         self._endpoints: Dict[str, Callable] = {}
-    def register(self, fqid: str, fn: Callable):
+
+    def register(self, fqid: str, fn: Callable) -> None:
         self._endpoints[fqid] = fn
-    def call(self, fqid: str, **kwargs):
+
+    def call(self, fqid: str, **kwargs) -> Result:
         fn = self._endpoints.get(fqid)
-        if not fn: return Result(ok=False, error=f"Unknown skill endpoint: {fqid}")
-        try: return Result(ok=True, data=fn(**kwargs))
-        except Exception as e: return Result(ok=False, error=str(e))
+        if not fn:
+            return Result(ok=False, error=f"Unknown skill endpoint: {fqid}")
+        try:
+            return Result(ok=True, data=fn(**kwargs))
+        except Exception as e:
+            return Result(ok=False, error=str(e))
+
+    def list_endpoints(self):
+        return sorted(self._endpoints.keys())
+
+
 registry = SkillRegistry()
+
+
 def endpoint(fqid: str):
-    def deco(fn): registry.register(fqid, fn); return fn
+    def deco(fn):
+        registry.register(fqid, fn)
+        return fn
+
     return deco
+
+
 def autoload_skills(root):
     pkg = "skills"
     for _, name, _ in pkgutil.iter_modules([str(root / pkg)]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 88
+extend-exclude = "ai/thalamus/bus.py"
+
+[tool.ruff]
+line-length = 88
+extend-exclude = ["ai/thalamus/bus.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,3 @@
+python -m venv .venv
+. .venv\Scripts\Activate.ps1
+pip install -r requirements.txt

--- a/scripts/run_dev.cmd
+++ b/scripts/run_dev.cmd
@@ -1,0 +1,4 @@
+@echo off
+call .venv\Scripts\activate.bat
+python -m cli.palette
+pause

--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -1,0 +1,4 @@
+$env:VENV = ".venv/"
+. $env:VENV\Scripts\Activate.ps1
+python -m cli.palette
+Read-Host "Press Enter to exit"

--- a/skills/config_editor/main.py
+++ b/skills/config_editor/main.py
@@ -1,10 +1,16 @@
+import os
+import subprocess
+
 import yaml
-from core.skill_api import endpoint
+
 from core.policy_engine import POLICY_PATH
+from core.skill_api import endpoint
+
 
 @endpoint("config.policy.get")
 def get():
     return yaml.safe_load(POLICY_PATH.read_text())
+
 
 @endpoint("config.policy.set")
 def set_value(key: str, value: str):
@@ -12,3 +18,10 @@ def set_value(key: str, value: str):
     data[key] = yaml.safe_load(value)
     POLICY_PATH.write_text(yaml.safe_dump(data))
     return "Policy updated."
+
+
+@endpoint("config.policy.edit")
+def edit():
+    editor = os.environ.get("EDITOR", "vi")
+    subprocess.run([editor, str(POLICY_PATH)])
+    return "Opened policy in editor."

--- a/skills/file_search/main.py
+++ b/skills/file_search/main.py
@@ -1,27 +1,55 @@
-import os, re
+import os
+import re
 from pathlib import Path
-from core.skill_api import endpoint
+
 from core.policy_engine import load_policy
+from core.skill_api import endpoint
+
+
 @endpoint("file.search.search")
 def search(query: str, limit: int = 50):
     pol = load_policy()
     rx = re.compile(re.escape(query), re.I)
     results = []
-    for base in pol.allowed_paths:
-        base = os.path.expandvars(base)
+    allowed = [os.path.expandvars(p) for p in pol.allowed_paths]
+    denied = [os.path.expandvars(p) for p in pol.denied_paths]
+    for base in allowed:
         for root, _, files in os.walk(base):
+            # skip denied paths
+            skip = False
+            for d in denied:
+                root_posix = Path(root).resolve().as_posix()
+                if root_posix.startswith(Path(d).resolve().as_posix()):
+                    skip = True
+                    break
+            if skip:
+                continue
             for f in files:
                 path = Path(root) / f
                 try:
-                    if path.suffix.lower() in (".txt",".md",".py",".c",".cpp",".h",".ini",".cfg",".json",".yaml",".yml"):
+                    if path.suffix.lower() in (
+                        ".txt",
+                        ".md",
+                        ".py",
+                        ".c",
+                        ".cpp",
+                        ".h",
+                        ".ini",
+                        ".cfg",
+                        ".json",
+                        ".yaml",
+                        ".yml",
+                    ):
                         with open(path, "r", errors="ignore") as fh:
                             text = fh.read()
                         m = rx.search(text)
                         if m:
-                            start = max(m.start()-40, 0); end = min(m.end()+40, len(text))
-                            snippet = text[start:end].replace("\n"," ")
+                            start = max(m.start() - 40, 0)
+                            end = min(m.end() + 40, len(text))
+                            snippet = text[start:end].replace("\n", " ")
                             results.append({"path": str(path), "snippet": snippet})
-                            if len(results) >= limit: return results
+                            if len(results) >= limit:
+                                return results
                 except Exception:
                     continue
     return results

--- a/skills/git/main.py
+++ b/skills/git/main.py
@@ -1,44 +1,55 @@
-import os, subprocess
+import os
+import subprocess
 from pathlib import Path
-from core.skill_api import endpoint
-from core.policy_engine import load_policy
 
-def _check_path(path: Path, pol):
-    path = path.resolve()
+from core.policy_engine import load_policy
+from core.skill_api import endpoint
+
+
+def _check_cwd(pol):
+    cwd = Path.cwd().resolve()
     for base in pol.allowed_paths:
         base_path = Path(os.path.expandvars(base)).resolve()
-        if str(path).startswith(str(base_path)):
+        if str(cwd).startswith(str(base_path)):
             for deny in pol.denied_paths:
                 deny_path = Path(os.path.expandvars(deny)).resolve()
-                if str(path).startswith(str(deny_path)):
+                if str(cwd).startswith(str(deny_path)):
                     raise RuntimeError("Path is denied by policy.")
             return
     raise RuntimeError("Path not allowed by policy.")
 
-def _git(args, cwd):
-    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
-    if proc.returncode != 0:
-        raise RuntimeError(proc.stderr.strip() or "git error")
-    return proc.stdout.strip() or "(no output)"
 
-@endpoint("git.clone")
-def clone(url: str, path: str):
-    pol = load_policy()
-    dest = Path(path).expanduser()
-    _check_path(dest, pol)
-    return _git(["clone", url, str(dest)], cwd=None)
+def _git(args):
+    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    out = (proc.stdout + proc.stderr).strip() or "(no output)"
+    if proc.returncode != 0:
+        out = f"[exit {proc.returncode}] {out}"
+    return out
+
 
 @endpoint("git.status")
-def status(path: str):
+def status():
     pol = load_policy()
-    repo = Path(path).expanduser()
-    _check_path(repo, pol)
-    return _git(["status"], cwd=str(repo))
+    _check_cwd(pol)
+    return _git(["status"])
 
-@endpoint("git.commit")
-def commit(path: str, message: str):
+
+@endpoint("git.diff_stat")
+def diff_stat():
     pol = load_policy()
-    repo = Path(path).expanduser()
-    _check_path(repo, pol)
-    _git(["add", "-A"], cwd=str(repo))
-    return _git(["commit", "-m", message], cwd=str(repo))
+    _check_cwd(pol)
+    return _git(["diff", "--stat"])
+
+
+@endpoint("git.branch")
+def branch():
+    pol = load_policy()
+    _check_cwd(pol)
+    return _git(["branch", "--show-current"])
+
+
+@endpoint("git.switch")
+def switch(name: str):
+    pol = load_policy()
+    _check_cwd(pol)
+    return _git(["switch", name])

--- a/skills/notes/main.py
+++ b/skills/notes/main.py
@@ -1,9 +1,15 @@
-from core.skill_api import endpoint
 from ai.hippocampus.memory import append_memory, read_memory
+from core.skill_api import endpoint
+
 NOTES_PREFIX = "[note] "
+
+
 @endpoint("notes.add")
 def add(text: str):
-    append_memory(NOTES_PREFIX + text); return "Added note."
+    append_memory(NOTES_PREFIX + text)
+    return "Added note."
+
+
 @endpoint("notes.list")
 def list_notes():
     data = read_memory()

--- a/skills/system_info/main.py
+++ b/skills/system_info/main.py
@@ -1,4 +1,9 @@
-import os, subprocess
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
 from core.skill_api import endpoint
 
 
@@ -13,6 +18,7 @@ def _read_meminfo():
         pass
     return info
 
+
 def _read_uptime():
     try:
         with open("/proc/uptime") as fh:
@@ -20,6 +26,7 @@ def _read_uptime():
             return int(up)
     except Exception:
         return 0
+
 
 @endpoint("system.info.get")
 def get():
@@ -36,10 +43,15 @@ def get():
             gpus.append({"name": name, "memory_total": memory})
     except Exception:
         pass
+    disk = shutil.disk_usage("/")
     return {
+        "os": platform.platform(),
+        "python": sys.version.split()[0],
         "cpu_count": os.cpu_count(),
         "ram_total": mem.get("MemTotal"),
         "ram_available": mem.get("MemAvailable"),
+        "disk_total": disk.total,
+        "disk_free": disk.free,
         "uptime_seconds": uptime,
         "gpus": gpus,
     }

--- a/skills/system_run/main.py
+++ b/skills/system_run/main.py
@@ -1,15 +1,39 @@
-import shlex, subprocess, os
-from core.skill_api import endpoint
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
 from core.policy_engine import load_policy
+from core.skill_api import endpoint
+
+ROOT = Path(__file__).resolve().parents[2]
+DENYLIST = {"rm", "sudo", "powershell"}
+
+
 @endpoint("system.run.exec")
-def exec(cmdline: str) -> str:
+def exec(cmdline: str, timeout: int = 30) -> str:
     pol = load_policy()
     parts = shlex.split(cmdline)
-    if not parts: return "No command."
+    if not parts:
+        return "No command."
     cmd = parts[0]
-    if cmd not in pol.allowed_commands:
+    if cmd in DENYLIST or cmd in getattr(pol, "denied_commands", []):
+        raise RuntimeError(f"Command '{cmd}' is denied by policy.")
+    if pol.allowed_commands and cmd not in pol.allowed_commands:
         raise RuntimeError(f"Command '{cmd}' is not allowed by policy.")
     env = os.environ.copy()
-    proc = subprocess.run(parts, capture_output=True, text=True, env=env)
-    out = proc.stdout + proc.stderr
-    return out.strip() if out.strip() else "(no output)"
+    try:
+        proc = subprocess.run(
+            parts,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(ROOT),
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("Command timed out.")
+    out = (proc.stdout + proc.stderr).strip() or "(no output)"
+    if proc.returncode != 0:
+        out = f"[exit {proc.returncode}] {out}"
+    return out

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.skill_api import autoload_skills, registry
+
+
+def test_system_info():
+    autoload_skills(Path(__file__).resolve().parents[1])
+    res = registry.call("system.info.get")
+    assert res.ok


### PR DESCRIPTION
## Summary
- add Windows launch and install scripts
- tighten policy and system.run safety
- add skill listing, policy editing, and git/system info helpers
- configure ruff/black with CI and simple tests

## Testing
- `ruff check .`
- `black .`
- `pytest`