### PR TITLE
feat(os): add Debian live-build profile for bootable HelmOS ISO

### DIFF
--- a/ai/hippocampus/memory.py
+++ b/ai/hippocampus/memory.py
@@ -1,9 +1,8 @@
-from pathlib import Path
-
 from cryptography.fernet import Fernet
+from core.paths import var_path
 
-KEY_PATH = Path("var/memory.key")
-MEMO_PATH = Path("var/memory.txt.enc")
+KEY_PATH = var_path("memory.key")
+MEMO_PATH = var_path("memory.txt.enc")
 
 
 def ensure_key():

--- a/core/audit_log.py
+++ b/core/audit_log.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from pathlib import Path
+from .paths import var_path
 
-LOG_PATH = Path("var/audit.log")
+LOG_PATH = var_path("audit.log")
 MAX_SIZE = 5 * 1024 * 1024  # 5MB
 
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import os
+
+
+def data_root() -> Path:
+    # Prefer a writable per-user data dir (works in live ISO)
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "helmos"
+    home = Path.home()
+    return home / ".local" / "share" / "helmos"
+
+
+def var_path(name: str) -> Path:
+    p = data_root()
+    p.mkdir(parents=True, exist_ok=True)
+    return p / name

--- a/os/debian-live/.gitignore
+++ b/os/debian-live/.gitignore
@@ -1,0 +1,12 @@
+
+build/
+cache/
+chroot/
+config/binary
+config/bootstrap
+config/chroot
+live-image-.iso
+live-image-.hybrid.iso
+work/
+tmp/
+config/includes.chroot/opt/HelmOS/**

--- a/os/debian-live/README.md
+++ b/os/debian-live/README.md
@@ -1,0 +1,31 @@
+# HelmOS Debian Live-Build Profile
+
+This profile builds a bootable ISO that autologins on TTY1 and auto-starts the HelmOS keyboard palette.
+
+## Host prerequisites (Debian/Ubuntu)
+```bash
+sudo apt-get update
+sudo apt-get install -y live-build syslinux-utils xorriso squashfs-tools rsync
+
+Prepare app files
+
+Copies the repo's HelmOS/ into the live image under /opt/HelmOS:
+
+cd os/debian-live
+./prepare.sh
+
+Build the ISO
+./build.sh
+
+
+Result: live-image-amd64.hybrid.iso in this directory.
+
+Notes
+
+The image autologins as user live on TTY1 and runs HelmOS.
+
+HelmOS persists runtime data in /home/live/.local/share/helmos/ (logs, memory).
+
+To customize packages, edit config/package-lists/helmos.list.chroot.
+
+To change autostart/service behavior, edit config/includes.chroot/etc/systemd/system/helmos.service.

--- a/os/debian-live/auto/config
+++ b/os/debian-live/auto/config
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lb config \
+  --mode debian \
+  --distribution bookworm \
+  --archive-areas "main contrib non-free non-free-firmware" \
+  --linux-packages linux-image \
+  --binary-images iso-hybrid \
+  --debian-installer none \
+  --apt-recommends false \
+  --memtest none

--- a/os/debian-live/build.sh
+++ b/os/debian-live/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Ensure app files are staged
+./prepare.sh
+
+# Configure live-build
+./auto/config
+
+# Build ISO
+sudo lb build
+
+echo
+echo "[+] Build complete. Look for live-image-amd64.hybrid.iso in $(pwd)"

--- a/os/debian-live/config/hooks/010-create-venv.chroot
+++ b/os/debian-live/config/hooks/010-create-venv.chroot
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+# Pre-create runtime directories and a writable data root for HelmOS
+install -d -m 0755 /home/live/.local/share/helmos
+chown -R live:live /home/live/.local/share/helmos
+
+# Move HelmOS logs/memory to a writable place via symlinks if app expects ./var
+# (Safe even if paths don't exist yet)
+mkdir -p /opt/HelmOS/var || true
+rm -f /opt/HelmOS/var/audit.log || true
+ln -sf /home/live/.local/share/helmos/audit.log /opt/HelmOS/var/audit.log
+
+# Create Python venv and install deps now (speeds first boot)
+cd /opt/HelmOS
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt

--- a/os/debian-live/config/hooks/020-enable-services.chroot
+++ b/os/debian-live/config/hooks/020-enable-services.chroot
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+# Create 'live' user and allow sudo (no password)
+useradd -m live || true
+passwd -d live || true
+usermod -aG sudo live || true
+
+# Enable our autostart service
+systemctl enable helmos.service

--- a/os/debian-live/config/includes.chroot/etc/systemd/system/getty@tty1.service.d/override.conf
+++ b/os/debian-live/config/includes.chroot/etc/systemd/system/getty@tty1.service.d/override.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin live --noclear %I 38400 linux
+Type=idle

--- a/os/debian-live/config/includes.chroot/etc/systemd/system/helmos.service
+++ b/os/debian-live/config/includes.chroot/etc/systemd/system/helmos.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=HelmOS Palette autostart (TTY)
+After=multi-user.target network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/HelmOS
+Environment=PYTHONUNBUFFERED=1
+# Ensure venv & deps, then run palette
+ExecStart=/bin/bash -lc '. .venv/bin/activate || python3 -m venv .venv && . .venv/bin/activate; pip -q install --upgrade pip; pip -q install -r requirements.txt; python -m cli.palette'
+Restart=on-failure
+User=live
+TTYPath=/dev/tty1
+StandardInput=tty
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/os/debian-live/config/package-lists/helmos.list.chroot
+++ b/os/debian-live/config/package-lists/helmos.list.chroot
@@ -1,0 +1,15 @@
+# base
+systemd-sysv
+sudo
+ca-certificates
+# python
+python3
+python3-venv
+python3-pip
+# cli niceties
+vim
+git
+htop
+less
+# optional firmware (uncomment if needed)
+# firmware-linux

--- a/os/debian-live/prepare.sh
+++ b/os/debian-live/prepare.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Sync the current repo's HelmOS app into the live-build includes directory.
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="$(cd "$(dirname "$0")" && pwd)/config/includes.chroot/opt/HelmOS"
+
+mkdir -p "$DEST"
+
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude 'os/debian-live' \
+  --exclude '.github' \
+  --exclude '.venv' \
+  --exclude '__pycache__' \
+  "$ROOT/HelmOS/" "$DEST/"
+
+echo "[+] Synced HelmOS -> $DEST"


### PR DESCRIPTION
## Summary
- add Debian live-build profile with autologin and HelmOS autostart
- helper scripts to sync app files and build ISO
- runtime paths use XDG data dir for logs and memory

## Testing
- `python -m py_compile core/paths.py core/audit_log.py ai/hippocampus/memory.py`
- `pytest`