### PR TITLE
Add skill list endpoint and expand README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ var/memory.*
 .build/
 pytest_cache/
 .ruff_cache/
+
+# OS build artifacts
+os/debian-live/build/
+os/debian-live/*.iso

--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
-# HelmOS — Agent‑First OS Layer (Keyboard‑First MVP)
+# HelmOS — Agent-First OS Layer (Keyboard-First MVP)
 
-Quick start:
+HelmOS is an experimental, agent-driven layer that turns a terminal into a keyboard-first operating experience. It ships with a small set of "skills" (pluggable commands) and runs entirely on your machine.
+
+## Topics
+- agents
+- operating-system
+- automation
+- cli
+
+## Quick start
 ```bash
 cd HelmOS
 ./scripts/install.sh
 ./scripts/run_dev.sh
 ```
 
-Windows quick start:
+### Windows quick start
 ```powershell
 cd HelmOS
 ./scripts/install.ps1
 ./scripts/run_dev.ps1
 ```
 
-Uninstall:
+## Uninstall
 ```
 Delete the HelmOS/ folder.
 ```
 
-Troubleshooting:
+## Build a bootable ISO (Debian live)
+To experiment with HelmOS as a live system, use the scripts under `os/debian-live/`:
+```
+cd os/debian-live
+./prepare.sh   # copy project files into the image
+./build.sh     # produce live-image-amd64.hybrid.iso
+```
 
+## Troubleshooting
 - Set PowerShell execution policy if scripts won't run: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`
 - Activate the virtual environment manually: `source .venv/bin/activate` (bash) or `. .venv\Scripts\Activate.ps1` (PowerShell)
-- Ensure Python 3.11+ is installed and on PATH.
+- Ensure Python 3.11+ is installed and on PATH
+- On Windows, running from a terminal with administrator privileges may help with package installs
 
-Privacy: HelmOS runs entirely locally; no data leaves your machine. Memory keys live under `var/memory.key`.
+## Privacy
+HelmOS runs entirely locally; no data leaves your machine. Memory keys live under `var/memory.key`.
+
+## License
+MIT – see [LICENSE](LICENSE).

--- a/skills/skill_list/main.py
+++ b/skills/skill_list/main.py
@@ -1,0 +1,7 @@
+from core.skill_api import endpoint, registry
+
+
+@endpoint("skills.list")
+def list_skills():
+    """Return a sorted list of registered skill endpoints."""
+    return registry.list_endpoints()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -10,3 +10,10 @@ def test_system_info():
     autoload_skills(Path(__file__).resolve().parents[1])
     res = registry.call("system.info.get")
     assert res.ok
+
+
+def test_skill_list():
+    autoload_skills(Path(__file__).resolve().parents[1])
+    res = registry.call("skills.list")
+    assert res.ok
+    assert "system.info.get" in res.data


### PR DESCRIPTION
## Summary
- add `skills.list` endpoint to enumerate available skills
- document project purpose, topics, and Debian live ISO build
- ignore Debian live build artifacts

## Testing
- `ruff check skills/skill_list/main.py skills/skill_list/__init__.py tests/test_skills.py`
- `black skills/skill_list/main.py skills/skill_list/__init__.py tests/test_skills.py`
- `pytest`
- ⚠️ `pre-commit run --files .gitignore README.md skills/skill_list/main.py skills/skill_list/__init__.py tests/test_skills.py` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_689ec7f9baa48332801508646338a6d4