### PR TITLE
Add CI workflows, Debian live ISO scaffolding, XDG paths and new skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ cd HelmOS
 Delete the HelmOS/ folder.
 ```
 
+## Built-in skills
+- `skills.list` — enumerate registered skill endpoints
+- `sys info` — report OS, CPU, memory, disk, and Python info
+
 ## Build a bootable ISO (Debian live)
 To experiment with HelmOS as a live system, use the scripts under `os/debian-live/`:
 ```


### PR DESCRIPTION
## Summary
- add GitHub Actions CI running lint checks and import smoke test
- scaffold manual Build ISO workflow
- introduce Debian live-build profile with scripts and service to autostart palette
- centralize writable data paths and rotate audit logs, storing encrypted memory
- expose `skills.list` and `sys.info.get` endpoints
- enforce timeout and exit code handling in `system.run.exec`
- document built-in skills in README

## Testing
- `ruff check --select=E,F --ignore=E501 .`
- `black --check .`
- `python - <<'PY'
import cli.palette
PY`
- `pytest`